### PR TITLE
Add ability to have multiple color variables with same HEX code

### DIFF
--- a/resources/style.css
+++ b/resources/style.css
@@ -187,6 +187,7 @@ input, textarea {
 .body {
   flex: 1;
   position: relative;
+  padding-top: 1.2rem;
   z-index: 1;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;

--- a/resources/webview.html
+++ b/resources/webview.html
@@ -9,13 +9,21 @@
     <div id="app" class="wrapper">
       <div class="header" data-app-region="drag">
         <h1 class="header-title">Sketch Dark Mode Palette</h1>
-        <button
-          class="settings-button"
-          v-on:click="toggleSettingsMenu()"
-        >
+      </div>
+      <div class="body" data-app-region="no-drag">
+        <div class="select-container">
+          <select v-model="selectedSchemeId" class="select">
+            <option
+              v-for="(scheme, id) in schemes"
+              :value="id"
+              :disabled="!scheme.enabled"
+            >
+              {{ scheme.name }}
+            </option>
+          </select>
           <svg
             xmlns="http://www.w3.org/2000/svg"
-            class="icon icon-tabler icon-tabler-settings"
+            class="icon icon-tabler icon-tabler-chevron-down"
             width="24"
             height="24"
             viewBox="0 0 24 24"
@@ -26,68 +34,10 @@
             stroke-linejoin="round"
           >
             <rect x="0" y="0" width="24" height="24" stroke="none"></rect>
-            <path
-              d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0 -1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 0 0 -2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0 -2.573 -1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 0 0 -1.065 -2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 0 0 1.066 -2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-            <circle cx="12" cy="12" r="3" />
+            <polyline points="6 9 12 15 18 9" />
           </svg>
-        </button>
-        <div
-          v-cloak
-          v-if="showSettingsMenu"
-          class="settings-menu"
-        >
-          <div
-            class="settings-menu-overlay"
-            v-on:click="toggleSettingsMenu()"
-          >
-          </div>
-          <ul>
-            <li v-on:click="selectScheme('document')">
-              <span>Document colors</span>
-              <span v-if="isDocumentSchemeSelected" class="dot">•</span>
-            </li>
-            <li v-on:click="selectScheme('library')">
-              <span>Library colors</span>
-              <span v-if="!isDocumentSchemeSelected" class="dot">•</span>
-            </li>
-          </ul>
         </div>
-      </div>
-      <div class="body" data-app-region="no-drag">
-        <div
-          v-cloak
-          v-if="!isDocumentSchemeSelected && libraries.length > 0"
-        >
-          <h4 class="small-heading">Libraries</h4>
-          <div class="select-container">
-            <select v-model="selectedLibraryId" class="select">
-              <option value="">Select a library</option>
-              <option
-                v-for="library in libraries"
-                :value="library.id"
-                :disabled="!library.enabled || !library.valid"
-              >
-                {{ library.name }}
-              </option>
-            </select>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              class="icon icon-tabler icon-tabler-chevron-down"
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              stroke-width="2"
-              stroke="currentColor"
-              fill="none"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            >
-              <rect x="0" y="0" width="24" height="24" stroke="none"></rect>
-              <polyline points="6 9 12 15 18 9" />
-            </svg>
-          </div>
-        </div>
-        <div v-cloak v-if="showErrorMessage" class="error-message">
+        <div v-cloak v-if="!showColors" class="error-message">
           <h2 class="error-message-title">
             🚀 Let's get started
           </h2>
@@ -100,7 +50,7 @@
         </div>
         <div
           v-cloak
-          v-if="showColorList"
+          v-if="showColors"
           class="colors-list"
         >
           <div

--- a/src/common.js
+++ b/src/common.js
@@ -88,7 +88,7 @@ export const switchArtboardTheme = (artboard) => {
     return
   }
 
-  artboard.background.color = switchColor(artboard.background.color)
+  artboard.background.color = switchColor(artboard.background.sketchObject.color())
 }
 
 /**
@@ -154,38 +154,28 @@ export const selectPage = (page) => {
 
 /**
  * 
- * @param {Color} color 
+ * @param {MSColor} color
  * @returns {Color}
  */
 const switchColor = (color) => {
-  if (baseColors.length > 0) {
-    const foundColor = baseColors.find((currentColor) => {
-      return currentColor.color === color
-    })
+  if (color.swatchID()) {
+    const foundColor = savedDarkThemeColors.find((darkThemeColor) => {
+      return (
+        darkThemeColor.name ==
+        doc.sketchObject
+          .documentData()
+          .sharedSwatches()
+          .swatchWithID(color.swatchID())
+          .name()
+      );
+    }).color;
 
     if (foundColor) {
-      return getDarkThemeColor(foundColor)
+      return foundColor;
     }
   }
 
-  return color
-}
-
-/**
- * 
- * @param {Color} baseColor 
- * @returns {Color}
- */
-const getDarkThemeColor = (baseColor) => {
-  const foundColor = savedDarkThemeColors.find((darkThemeColor) => {
-    return darkThemeColor.name === baseColor.name
-  })
-
-  if (foundColor) {
-    return foundColor.color
-  }
-
-  return baseColor.color
+  return color;
 }
 
 /**
@@ -193,7 +183,7 @@ const getDarkThemeColor = (baseColor) => {
  * @param {Text} textLayer 
  */
 const switchTextTheme = (textLayer) => {
-  textLayer.style.textColor = switchColor(textLayer.style.textColor)
+  textLayer.style.textColor = switchColor(textLayer.style.sketchObject.textStyle().attributes().MSAttributedStringColorAttribute)
 }
 
 /**
@@ -209,14 +199,14 @@ const switchShapeTheme = (shapeLayer) => {
         const fillType = hasSketchFillTypeSupport() ? style.fillType : style.fill
 
         if (fillType === Style.FillType.Color) {
-          style.color = switchColor(style.color)
+          style.color = switchColor(style.sketchObject.color())
         }
 
         if (fillType === Style.FillType.Gradient) {
           const stops = style.gradient.stops
 
           for (let i = 0, l = stops.length; i < l; i++) {
-            stops[i].color = switchColor(stops[i].color)
+            stops[i].color = switchColor(stops[i].sketchObject.color())
           }
         }
 

--- a/src/common.js
+++ b/src/common.js
@@ -159,23 +159,25 @@ export const selectPage = (page) => {
  */
 const switchColor = (color) => {
   if (color.swatchID()) {
-    const foundColor = savedDarkThemeColors.find((darkThemeColor) => {
-      return (
-        darkThemeColor.name ==
-        doc.sketchObject
-          .documentData()
-          .sharedSwatches()
-          .swatchWithID(color.swatchID())
-          .name()
-      );
-    }).color;
+    const swatch = doc.sketchObject
+      .documentData()
+      .sharedSwatches()
+      .swatchWithID(color.swatchID())
 
-    if (foundColor) {
-      return foundColor;
+    if (swatch) {
+      const foundColor = savedDarkThemeColors.find((darkThemeColor) => {
+        return (
+          darkThemeColor.name == swatch.name()
+        )
+      }).color
+
+      if (foundColor) {
+        return foundColor
+      }
     }
   }
 
-  return color;
+  return color
 }
 
 /**

--- a/src/common.js
+++ b/src/common.js
@@ -227,6 +227,8 @@ const switchShapeTheme = (shapeLayer) => {
 const switchSymbolInstanceTheme = (symbolInstance) => {
   const group = symbolInstance.detach()
 
+  switchShapeTheme(group)
+
   if (!hasSketchFindMethodSupport()) {
     switchNativeLayersBasedOnType(group, 'SymbolInstance')
   } else {

--- a/src/common.js
+++ b/src/common.js
@@ -158,25 +158,32 @@ export const selectPage = (page) => {
  * @returns {Color}
  */
 const switchColor = (color) => {
+
+  // Ensure color is associated with a color variable
   if (color.swatchID()) {
+
+    // Get associated color variable
     const swatch = doc.sketchObject
       .documentData()
       .sharedSwatches()
       .swatchWithID(color.swatchID())
 
+    // Ensure color variable hasn’t been deleted
     if (swatch) {
-      const foundColor = savedDarkThemeColors.find((darkThemeColor) => {
-        return (
-          darkThemeColor.name == swatch.name()
-        )
-      }).color
 
+      // Look for dark theme color based on color variable name
+      const foundColor = savedDarkThemeColors.find((darkThemeColor) => {
+        return darkThemeColor.name == swatch.name()
+      })
+
+      // Make sure a dark theme color for this color variable exists
       if (foundColor) {
-        return foundColor
+        return foundColor.color
       }
     }
   }
 
+  // Return same color if no dark theme color is found
   return color
 }
 

--- a/src/common.js
+++ b/src/common.js
@@ -88,7 +88,7 @@ export const switchArtboardTheme = (artboard) => {
     return
   }
 
-  artboard.background.color = switchColor(artboard.background.sketchObject.color())
+  artboard.background.color = switchColor(artboard.sketchObject.backgroundColor())
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,26 +7,8 @@ import sketch from 'sketch/dom'
  * @returns {Object}
  */
 export const getDocumentData = (doc) => {
-  const settingsSchemeTypeKey = `${doc.id}-dark-theme-scheme-type`
-  const settingsDarkThemeColorsKey = `${doc.id}-dark-theme-colors`
-  const settingsSelectedLibraryKey = `${doc.id}-dark-theme-selected-library`
-
-  const savedSchemeType =
-    Settings.settingForKey(settingsSchemeTypeKey) ||
-    Settings.documentSettingForKey(doc, settingsSchemeTypeKey)
-  const savedDarkThemeColors =
-    Settings.settingForKey(settingsDarkThemeColorsKey) ||
-    Settings.documentSettingForKey(doc, settingsDarkThemeColorsKey)
-  const savedLibraryId =
-    Settings.settingForKey(settingsSelectedLibraryKey) ||
-    Settings.documentSettingForKey(doc, settingsSelectedLibraryKey)
-
-  return {
-    savedSchemeType:
-      typeof savedSchemeType !== 'undefined' ? savedSchemeType : 'document',
-    savedDarkThemeColors,
-    savedLibraryId
-  }
+  return Settings.settingForKey(`${doc.id}-dark-mode-colors`) ||
+    Settings.documentSettingForKey(doc, `${doc.id}-dark-mode-colors`)
 }
 
 /**
@@ -74,33 +56,4 @@ export const hasSketchFillTypeSupport = () => {
  */
 export const hasSketchColorVariablesSupport = () => {
   return isSketchVersion(69)
-}
-
-/**
- * 
- * @param {Document} doc 
- * @return {Array}
- */
-export const getDocumentColors = (doc) => {
-  const legacyColors = doc.colors
-
-  if (hasSketchColorVariablesSupport() && doc.swatches.length > 0) {
-    // Renames Color Variables based on legacy colors
-    if (legacyColors.length > 0) {
-      doc.swatches.forEach((swatch) => {
-        const swatchColorName = swatch.name.substr(3)
-        const foundLegacyColor = legacyColors.find((legacyColor) => {
-          return swatchColorName === legacyColor.name
-        })
-
-        if (foundLegacyColor) {
-          swatch.name = foundLegacyColor.name
-        }
-      })
-    }
-
-    return doc.swatches
-  }
-
-  return legacyColors
 }


### PR DESCRIPTION
This PR adds the ability to have multiple color variables with the same HEX code and still be able to assign each one a separate dark mode value.

Closes #33

And fixed problem causing dark mode colours not to be applied to a symbols tint.